### PR TITLE
dockerctl: use 'podman' if present and 'docker version' fails

### DIFF
--- a/karton/dockerctl.py
+++ b/karton/dockerctl.py
@@ -41,6 +41,23 @@ class Docker(object):
     # Another, unexpected, error happened while trying to use a Docker command.
     _DOCKER_OTHER_ERROR = 10
 
+    def _can_use_podman(self):
+        '''
+        Try running Podman to check its availability.
+
+
+        Return value:
+            True if Podman is available; False otherwise.
+        '''
+        try:
+            proc.check_output(
+                ['podman', 'version'],
+                stderr=proc.DEVNULL)
+        except OSError:
+            return False
+        else:
+            return True
+
     def _try_docker(self):
         '''
         Try running Docker to check its availability.
@@ -140,6 +157,11 @@ class Docker(object):
 
         if status == self._DOCKER_SUCCESS:
             return
+
+        elif self._can_use_podman():
+            verbose("Found 'podman'; using it instead of docker")
+            self._docker_command = ['podman']
+            return self._DOCKER_SUCCESS
 
         elif status == self._DOCKER_NO_COMMAND:
             if sys.platform == 'darwin':

--- a/karton/dockerctl.py
+++ b/karton/dockerctl.py
@@ -74,7 +74,7 @@ class Docker(object):
             json_output = proc.check_output(
                 self._docker_command + ['version', '--format', '{{ json . }}'],
                 stderr=proc.DEVNULL)
-        except OSError as exc:
+        except OSError:
             return self._DOCKER_NO_COMMAND
         except proc.CalledProcessError as exc:
             # The most common case for this is that the server cannot be contacted, so


### PR DESCRIPTION
`podman` is an almost-CLI-compatible replacement for `docker`, which
allows unprivileged users to run containers, with no daemon. On some
systems, `docker` is a symbolic link to `podman`.

I say "almost" because one command that is not compatible is `docker
version --format '{{ json . }}'`, used by Karton to detect whether
docker is present and usable.
https://github.com/containers/libpod/issues/2671

To work around this, if _try_docker() fails, but running `podman
version` succeeds, use `podman` instead. Otherwise, behave as before.