### PR TITLE
WIP: support using UID 0 inside the container

### DIFF
--- a/karton/emit.py
+++ b/karton/emit.py
@@ -121,7 +121,7 @@ class Emitter(object):
             self._emit('MAINTAINER %s' % self._props.maintainer)
             self._emit()
 
-    def _emit_addittional_archs(self):
+    def _emit_additional_archs(self):
         if self._props.additional_archs:
             archs_run = ['RUN \\']
             for i, arch in enumerate(self._props.additional_archs):
@@ -235,7 +235,7 @@ class Emitter(object):
         '''
         self._emit_intro()
         self._emit_run_for_time(DefinitionProperties.RUN_AT_BUILD_START)
-        self._emit_addittional_archs()
+        self._emit_additional_archs()
         self._emit_system_packages()
         self._emit_run_for_time(DefinitionProperties.RUN_AT_BUILD_BEFORE_USER_PKGS)
         self._emit_install(*self._props.packages)

--- a/karton/emit.py
+++ b/karton/emit.py
@@ -196,20 +196,31 @@ class Emitter(object):
                     ))
 
     def _emit_user_creation(self):
-        self._emit(
-            r'''
-            RUN \
-                mkdir -p $(dirname %(user_home)s) && \
-                useradd -m -s /bin/bash --home-dir %(user_home)s --uid %(uid)s %(username)s && \
-                chown %(username)s %(user_home)s
-            ENV USER %(username)s
-            USER %(username)s
-            '''
-            % dict(
-                username=self._props.username,
-                uid=self._props.uid,
-                user_home=self._props.user_home,
-                ))
+        if self._props.uid == 0:
+            self._emit(
+                r"""
+                RUN \
+                    mkdir -p $(dirname %(user_home)s)
+                ENV HOME $(user_home)s
+                """
+                % dict(
+                    user_home=self._props.user_home,
+                    ))
+        else:
+            self._emit(
+                r'''
+                RUN \
+                    mkdir -p $(dirname %(user_home)s) && \
+                    useradd -m -s /bin/bash --home-dir %(user_home)s --uid %(uid)s %(username)s && \
+                    chown %(username)s %(user_home)s
+                ENV USER %(username)s
+                USER %(username)s
+                '''
+                % dict(
+                    username=self._props.username,
+                    uid=self._props.uid,
+                    user_home=self._props.user_home,
+                    ))
 
     def _emit_copy_files(self):
         for i, (src_path, dest_path) in enumerate(self._props.copied):


### PR DESCRIPTION
When using podman as an unprivileged user, UID 0 in the container is mapped to your real UID outside the container. Karton's behaviour of creating a "mirror" unprivileged user inside the container is undesirable because its UID inside the container (in my case, 1001) is mapped to something else (in my case, 166536) outside, so I now have files in my homedir that I don't own.

Previously, setting props.uid = 0 would fail with:

    STEP 26: RUN     mkdir -p $(dirname /sysroot/home/wjt) &&
                     useradd -m -s /bin/bash --home-dir /sysroot/home/wjt --uid 0 wjt &&
                     chown wjt /sysroot/home/wjt
    useradd: UID 0 is not unique

With this change, setting:

    props.uid = 0
    props.sudo = props.SUDO_NO

seems to do the right thing.

This commit is WIP because:

* props.username is part-ignored with this change,
* I think this behaviour should be used automatically when using podman as an unprivileged user
* I haven't tested it much